### PR TITLE
CLN-31236: allow the number input more flexible

### DIFF
--- a/src/commands/index.js
+++ b/src/commands/index.js
@@ -873,7 +873,10 @@ const editCommandDefs = {
               props.annotationVisibilityShow("orfs");
               props.minimumOrfSizeUpdate(minimumOrfSize);
             }}
-            value={props.minimumOrfSize}
+            defaultValue={props.minimumOrfSize}
+            onBlur={function (event) {
+              event.target.value = props.minimumOrfSize;
+            }}
           />
         </div>
       );

--- a/src/commands/index.js
+++ b/src/commands/index.js
@@ -875,6 +875,7 @@ const editCommandDefs = {
             }}
             defaultValue={props.minimumOrfSize}
             onBlur={function (event) {
+              // show the valid value in input when blurred
               event.target.value = props.minimumOrfSize;
             }}
           />


### PR DESCRIPTION
We can't delete that number just by hitting delete.  I can select all and change the number, but users should be able to change the number without selecting it first.