### PR TITLE
CLN-31995: ORFs AA size should not include the terminal codon translation * 

### DIFF
--- a/src/helperComponents/PropertiesDialog/OrfProperties.js
+++ b/src/helperComponents/PropertiesDialog/OrfProperties.js
@@ -43,7 +43,7 @@ class OrfProperties extends React.Component {
           strand: orf.forward ? 1 : -1
         }),
         size: getRangeLength(orf, sequenceLength),
-        sizeAa: Math.floor(getRangeLength(orf, sequenceLength) / 3)
+        sizeAa: Math.floor(getRangeLength(orf, sequenceLength) / 3 - 1)
       };
     });
     return (


### PR DESCRIPTION
When a DNA/RNA translated to AA sequence in ORFs, a terminal codon translation * is always included, this is not a valid AA, we should reduce one AA from the AA size.

E.g: this sequence
`atgactgaatacaagcctactgtcaggttggctacaagagacgacgttcctagagccgtgagaactctggctgcagccttcgccgactaccccgccacgagacacaccgttgacccagatcggcatattgagagagtgactgaactgcaggagctgtttcttacaagagttggcctcgacataggcaaggtgtgggtggcggacgacggcgccgccgtggccgtctggaccactcccgaatcagttgaggctggcgccgtattcgctgagatcggcccgagaatggctgagctcagcgggagtaggctcgcggcacagcagcaaatggagggactgctggcaccacacaggcccaaagaacccgcctggttcctggcaaccgtcggtgtatctcccgatcatcaggggaaaggtctgggctctgccgtagtgctccctggcgtggaggcagctgagagagcaggagtacctgccttcttggagacctccgctccaaggaatcttcccttctatgaacggttgggcttcaccgtgacagccgacgtggaagtccccgaaggcccccgcacttggtgcatgacgaggaagcctggagcgtga`
is translate to AA sequence `MTEYKPTVRLATRDDVPRAVRTLAAAFADYPATRHTVDPDRHIERVTELQELFLTRVGLDIGKVWVADDGAAVAVWTTPESVEAGAVFAEIGPRMAELSGSRLAAQQQMEGLLAPHRPKEPAWFLATVGVSPDHQGKGLGSAVVLPGVEAAERAGVPAFLETSAPRNLPFYERLGFTVTADVEVPEGPRTWCMTRKPGA*`
This AA string size is 200, but the actual valid AA size should be 199.



